### PR TITLE
Enable automatic library addition from gene search

### DIFF
--- a/index.html
+++ b/index.html
@@ -824,7 +824,9 @@ document.addEventListener('DOMContentLoaded',() => {
             geneSearchInput.value = symbol;
             closeAutocompleteDropdown();
             selectedGeneSymbol = symbol;
-            addGeneBtn.disabled = false;
+            addLibraryModule(symbol);
+            geneSearchInput.value = '';
+            addGeneBtn.disabled = true;
             filterGeneModules();
           });
           row.addEventListener('mouseenter', () => {
@@ -1074,22 +1076,41 @@ document.addEventListener('DOMContentLoaded',() => {
   // Initialize visibility
   showUserLibraryIfNeeded();
 
-  // Ensure user library is always visible and updated after Add
-  addGeneBtn.addEventListener('click', function() {
-    if (!selectedGeneSymbol) return;
+  function addLibraryModule(symbol) {
+    symbol = symbol.trim().toUpperCase();
+    if (!symbol) return;
     const type = selectedPerturbationType;
-    let displayGene = selectedGeneSymbol;
+    let displayGene = symbol;
     let moduleType = 'overexpression';
-    if (type === 'KO') { displayGene = `KO:${selectedGeneSymbol}`; moduleType = 'gRNA'; }
-    else if (type === 'KD') { displayGene = `KD:${selectedGeneSymbol}`; moduleType = 'gRNA'; }
-    else if (type === 'KU') { displayGene = `KU:${selectedGeneSymbol}`; moduleType = 'overexpression'; }
+    if (type === 'KO' || type === 'KD') {
+      displayGene = `${type}:${symbol}`;
+      moduleType = 'gRNA';
+    } else if (type === 'KU') {
+      displayGene = `KU:${symbol}`;
+    }
     userLibrary.push(displayGene);
     userLibraryTypes.push(moduleType);
     renderUserLibrary();
     userLibraryContainer.style.display = 'flex';
+  }
+
+  // Ensure user library is always visible and updated after Add
+  addGeneBtn.addEventListener('click', function() {
+    addLibraryModule(geneSearchInput.value);
     selectedGeneSymbol = null;
     geneSearchInput.value = '';
     this.disabled = true;
+  });
+
+  geneSearchInput.addEventListener('keypress', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      addLibraryModule(geneSearchInput.value);
+      geneSearchInput.value = '';
+      selectedGeneSymbol = null;
+      addGeneBtn.disabled = true;
+      closeAutocompleteDropdown();
+    }
   });
 
   // Multi-cassette internal mode
@@ -1486,82 +1507,6 @@ document.addEventListener('mousedown', function(e) {
   renderInitialGeneModules();
   renderUserLibrary();
 
-  // --- FIX: ADD THIS ENTIRE BLOCK TO YOUR SCRIPT ---
-
-  // Make sure you have the elements needed for this feature
-  const addGeneBtn = document.getElementById('add-gene-btn');
-  const geneSearchInput = document.getElementById('gene-search-input');
-  const perturbationDropdown = document.getElementById('perturbation-type-dropdown');
-  
-  // This is the container for user-added modules we discussed previously
-  // Ensure it's defined and present in the DOM
-  const userLibraryContainer = document.getElementById('user-library-container');
-
-  // This function contains the logic to create and add a new module
-  function addNewPerturbation() {
-    const geneName = geneSearchInput.value.trim().toUpperCase();
-    if (!geneName) {
-      // Don't do anything if the input is empty
-      return; 
-    }
-
-    const perturbationPrefix = perturbationDropdown.value; // e.g., 'KI', 'KO'
-    
-    // Your code uses internal types 'overexpression' and 'gRNA'. Let's map to them.
-    let internalType;
-    let fullGeneId = geneName; // Default for KI
-
-    switch(perturbationPrefix) {
-        case 'KI':
-        case 'KU':
-            internalType = 'overexpression';
-            // Prepend KU: for knock-up
-            if (perturbationPrefix === 'KU') fullGeneId = `KU:${geneName}`;
-            break;
-        case 'KO':
-        case 'KD':
-            internalType = 'gRNA';
-            // Prepend KO: or KD: for knock-out/down
-            fullGeneId = `${perturbationPrefix}:${geneName}`;
-            break;
-        default:
-            internalType = 'overexpression';
-    }
-
-    // Create the new draggable element
-    const newModule = document.createElement('div');
-    newModule.className = 'gene-module';
-    newModule.textContent = geneName; // Display only the gene name
-    newModule.dataset.gene = fullGeneId; // Store the full identifier
-    newModule.dataset.type = internalType;
-    newModule.draggable = true;
-
-    // Add the drag-and-drop functionality
-    newModule.addEventListener('dragstart', (e) => {
-      e.dataTransfer.setData('gene', newModule.dataset.gene);
-      e.dataTransfer.setData('type', newModule.dataset.type);
-    });
-
-    // **Crucially, add the new module to your user-specific container**
-    // This prevents it from being deleted if the initial modules are ever re-rendered.
-    userLibraryContainer.appendChild(newModule);
-
-    // Clear the input field for the next entry
-    geneSearchInput.value = '';
-  }
-
-  // 1. Attach the function to the 'Add' button
-  addGeneBtn.addEventListener('click', addNewPerturbation);
-
-  // 2. (Optional but recommended) Allow adding by pressing 'Enter'
-  geneSearchInput.addEventListener('keypress', (event) => {
-    if (event.key === 'Enter') {
-      event.preventDefault(); // Prevents any default browser action
-      addNewPerturbation();
-    }
-  });
-
-  // --- END OF FIX ---
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- remove outdated block that duplicated library logic
- add helper `addLibraryModule` for creating user library items
- automatically add selected search result to the library
- allow pressing Enter or Add button to create draggable library modules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688194a240708332a755aaedc3e1271a